### PR TITLE
Fixed chatterino version API

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -12,9 +12,9 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v2.3.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: "v1.39.0"
+          version: "v1.40.1"

--- a/demo.yaml
+++ b/demo.yaml
@@ -52,6 +52,30 @@ discord:
   webhook: ["<webhook_id>", "<webhook_token>"] 
 
 chatterino:
-  version: "7.0.0"
-  portable_download: ""
-  update: ""
+  version: "7.3.2"
+  stable:
+    win:
+      download: "https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino.Installer.exe"
+      portable_download: "https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino.Portable.zip"
+      updateexe: "https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino.Installer.exe"
+    linux:
+      download: "https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino-x86_64.AppImage"
+      portable_download: ""
+      updateexe: ""
+    macos:
+      download: "https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino.dmg"
+      portable_download: ""
+      updateexe: "https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino.dmg"
+  beta:
+    win:
+      download: "https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino.Installer.exe"
+      portable_download: "https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino.Portable.zip"
+      updateexe: "https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino.Installer.exe"
+    linux:
+      download: "https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino-x86_64.AppImage"
+      portable_download: ""
+      updateexe: ""
+    macos:
+      download: "https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino.dmg"
+      portable_download: ""
+      updateexe: "https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino.dmg"

--- a/src/server/api/v2/chatterino/chattterino.go
+++ b/src/server/api/v2/chatterino/chattterino.go
@@ -11,12 +11,16 @@ import (
 func Chatterino(app fiber.Router) fiber.Router {
 	chatterino := app.Group("/chatterino")
 
-	chatterino.Get("/version/:platform/stable", func(c *fiber.Ctx) error {
-		portableDownload := configure.Config.GetString(fmt.Sprintf("chatterino.portable_download.%v", c.Params("platform")))
+	chatterino.Get("/version/:os/:branch", func(c *fiber.Ctx) error {
+		download := configure.Config.GetString(fmt.Sprintf("chatterino.%s.%s.download", c.Params("branch"), c.Params("os")))
+		portableDownload := configure.Config.GetString(fmt.Sprintf("chatterino.%s.%s.portable_download", c.Params("branch"), c.Params("os")))
+		updateExe := configure.Config.GetString(fmt.Sprintf("chatterino.%s.%s.updateexe", c.Params("branch"), c.Params("os")))
 		version := configure.Config.GetString("chatterino.version")
 
 		result := VersionResult{
+			download,
 			portableDownload,
+			updateExe,
 			version,
 		}
 
@@ -32,6 +36,8 @@ func Chatterino(app fiber.Router) fiber.Router {
 }
 
 type VersionResult struct {
+	Download         string `json:"download"`
 	PortableDownload string `json:"portable_download"`
+	UpdateExe        string `json:"updateexe"`
 	Version          string `json:"version"`
 }

--- a/src/server/api/v2/chatterino/chattterino.go
+++ b/src/server/api/v2/chatterino/chattterino.go
@@ -29,6 +29,7 @@ func Chatterino(app fiber.Router) fiber.Router {
 			return c.Status(500).SendString(err.Error())
 		}
 
+		c.Set("Content-Type", "application/json")
 		return c.Status(200).Send(b)
 	})
 


### PR DESCRIPTION
Replicates behavoir used in `https://notitia.chatterino.com/version/chatterino/:os/:branch`
Also renamed fiber's parameters to be consistent with chatterino's naming in `Updates.cpp`
