### PR TITLE
Deploy job - Revert back to working version

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,7 +21,7 @@ jobs:
       # Build image
       - name: Build Image
         id: build_step
-        uses: docker/build-push-action@v2.5.0
+        uses: docker/build-push-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
Reverting back to docker/build-push-action@v1 as the newer version don't work with push. Getting the same outcome with the latest version should be possible and looked into though.