### PR TITLE
Bump version in chatterino API to 7.3.3

### DIFF
--- a/demo.yaml
+++ b/demo.yaml
@@ -41,30 +41,30 @@ discord:
   # 1: webhook token
   webhook: [<webhook_id>, <webhook_token>] 
 chatterino:
-  version: 7.3.2
+  version: 7.3.3
   stable:
     win:
-      download: https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino.Installer.exe
-      portable_download: https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino.Portable.zip
-      updateexe: https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino.Installer.exe
+      download: https://github.com/SevenTV/chatterino7/releases/download/7.3.3/Chatterino.Installer.exe
+      portable_download: https://github.com/SevenTV/chatterino7/releases/download/7.3.3/Chatterino.Portable.zip
+      updateexe: https://github.com/SevenTV/chatterino7/releases/download/7.3.3/Chatterino.Installer.exe
     linux:
-      download: https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino-x86_64.AppImage
+      download: https://github.com/SevenTV/chatterino7/releases/download/7.3.3/Chatterino-x86_64.AppImage
       portable_download: 
       updateexe: 
     macos:
-      download: https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino.dmg
+      download: https://github.com/SevenTV/chatterino7/releases/download/7.3.3/Chatterino.dmg
       portable_download: 
-      updateexe: https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino.dmg
+      updateexe: https://github.com/SevenTV/chatterino7/releases/download/7.3.3/Chatterino.dmg
   beta:
     win:
-      download: https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino.Installer.exe
-      portable_download: https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino.Portable.zip
-      updateexe: https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino.Installer.exe
+      download: https://github.com/SevenTV/chatterino7/releases/download/7.3.3/Chatterino.Installer.exe
+      portable_download: https://github.com/SevenTV/chatterino7/releases/download/7.3.3/Chatterino.Portable.zip
+      updateexe: https://github.com/SevenTV/chatterino7/releases/download/7.3.3/Chatterino.Installer.exe
     linux:
-      download: https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino-x86_64.AppImage
+      download: https://github.com/SevenTV/chatterino7/releases/download/7.3.3/Chatterino-x86_64.AppImage
       portable_download: 
       updateexe: 
     macos:
-      download: https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino.dmg
+      download: https://github.com/SevenTV/chatterino7/releases/download/7.3.3/Chatterino.dmg
       portable_download: 
-      updateexe: https://github.com/SevenTV/chatterino7/releases/download/7.3.2/Chatterino.dmg
+      updateexe: https://github.com/SevenTV/chatterino7/releases/download/7.3.3/Chatterino.dmg


### PR DESCRIPTION
As based on upstream, Chatterino has commited an update to v2.3.3 (it is just not released yet). It was confirmed by fourtf that Chatterino2 v2.3.3 will be based on 0021290 - our last commit on Chatterino7 (20a7127) is up to date with all upstream changes and fixes flaws on our side as well 🚀
