### PR TITLE
Hotfix - Force FFZ Emotes

### DIFF
--- a/src/server/api/v2/gql/resolvers/query/query.go
+++ b/src/server/api/v2/gql/resolvers/query/query.go
@@ -459,6 +459,13 @@ func (*QueryResolver) ThirdPartyEmotes(ctx context.Context, args struct {
 		return nil, resolvers.ErrDepth
 	}
 
+	// TEMPORARY FIX:
+	// FORCE FFZ EMOTES.
+	// THIS SHOULD BE REMOVED WHEN THE WEB EXTENSION IS FIXED
+	if !utils.Contains(args.Providers, "FFZ") {
+		args.Providers = append(args.Providers, "FFZ")
+	}
+
 	// Query foreign APIs for requested third party emotes
 	var emotes []*datastructure.Emote
 	var globalEmotes []*datastructure.Emote


### PR DESCRIPTION
I did an oopsie with the latest browser extension update and it no longer requests FFZ emotes. This means any client without FFZ won't see their emotes while using 7TV. This is very temporary workaround which forces FFZ emotes regardless of whether it was requested in the `ThirdPartyEmotes` GQL endpoint.