### PR TITLE
GQL - Add Broadcast & FollowerCount Query to User

### DIFF
--- a/src/cache/cache.go
+++ b/src/cache/cache.go
@@ -288,10 +288,17 @@ func CacheGetRequest(ctx context.Context, uri string, cacheDuration time.Duratio
 		req.Header.Add(header.Key, header.Value)
 	}
 
+	startedAt := time.Now()
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
+	log.WithFields(log.Fields{
+		"status_code":    resp.StatusCode,
+		"status":         resp.Status,
+		"response_in_ms": time.Now().Sub(startedAt).Milliseconds(),
+		"completed_at":   time.Now(),
+	}).Info("CacheGetRequest")
 
 	// Read the body as byte slice
 	body, err := ioutil.ReadAll(resp.Body)

--- a/src/mongo/datastructure/datastructure.go
+++ b/src/mongo/datastructure/datastructure.go
@@ -235,40 +235,6 @@ type Report struct {
 	AuditEntries *[]*AuditLog `json:"audit_entries" bson:"-"`
 }
 
-// const (
-// 	oldAuditLogTypeEmoteCreate int32 = 1
-// 	oldAuditLogTypeEmoteDelete int32 = iota
-// 	oldAuditLogTypeEmoteDisable
-// 	oldAuditLogTypeEmoteEdit
-// 	oldAuditLogTypeEmoteUndoDelete
-
-// 	oldAuditLogTypeAuthIn  int32 = 21
-// 	oldAuditLogTypeAuthOut int32 = iota
-
-// 	oldAuditLogTypeUserCreate int32 = 31
-// 	oldAuditLogTypeUserDelete int32 = iota
-// 	oldAuditLogTypeUserBan
-// 	oldAuditLogTypeUserEdit
-// 	oldAuditLogTypeUserChannelEmoteAdd
-// 	oldAuditLogTypeUserChannelEmoteRemove
-// 	oldAuditLogTypeUserUnban
-// 	oldAuditLogTypeUserChannelEditorAdd
-// 	oldAuditLogTypeUserChannelEditorRemove
-// 	oldAuditLogTypeUserChannelEmoteEdit
-
-// 	oldAuditLogTypeAppMaintenanceMode int32 = 51
-// 	oldAuditLogTypeAppRouteLock       int32 = iota
-// 	oldAuditLogTypeAppLogsView
-// 	oldAuditLogTypeAppScale
-// 	oldAuditLogTypeAppNodeCreate
-// 	oldAuditLogTypeAppNodeDelete
-// 	oldAuditLogTypeAppNodeJoin
-// 	oldAuditLogTypeAppNodeUnref
-
-// 	oldAuditLogTypeReport      int32 = 71
-// 	oldAuditLogTypeReportClear int32 = iota
-// )
-
 const (
 	// Emotes (1-19)
 	AuditLogTypeEmoteCreate     = 1
@@ -318,4 +284,19 @@ type Badge struct {
 type Meta struct {
 	Announcement      string `json:"announcement"`
 	FeaturedBroadcast string `json:"featured_broadcast"`
+}
+
+type Broadcast struct {
+	ID           string   `json:"id"`
+	Title        string   `json:"title"`
+	ThumbnailURL string   `json:"thumbnail_url"`
+	ViewerCount  int32    `json:"viewer_count"`
+	Type         string   `json:"type"`
+	GameName     string   `json:"game_name"`
+	GameID       string   `json:"game_id"`
+	Language     string   `json:"language"`
+	Tags         []string `json:"tags"`
+	Mature       bool     `json:"mature"`
+	StartedAt    string   `json:"started_at"`
+	UserID       string   `json:"user_id"`
 }

--- a/src/server/api/v2/gql/resolvers/query/user.go
+++ b/src/server/api/v2/gql/resolvers/query/user.go
@@ -499,3 +499,41 @@ func (r *UserResolver) AuditEntries() (*[]*auditResolver, error) {
 func (r *UserResolver) EmoteSlots() int32 {
 	return r.v.GetEmoteSlots()
 }
+
+// Get user's folloer count
+func (r *UserResolver) FollowerCount() int32 {
+	count, err := api_proxy.GetTwitchFollowerCount(r.ctx, r.v.TwitchID)
+	if err != nil {
+		return 0
+	}
+
+	return count
+}
+
+// Get user's live broadcast, if any
+func (r *UserResolver) Broadcast() (*datastructure.Broadcast, error) {
+	var stream *datastructure.Broadcast
+	if streams, err := api_proxy.GetTwitchStreams(r.ctx, r.v.Login); err != nil {
+		return nil, err
+	} else if len(streams.Data) > 0 {
+		s := streams.Data[0]
+		stream = &datastructure.Broadcast{
+			ID:           s.ID,
+			Title:        s.Title,
+			ThumbnailURL: s.ThumbnailURL,
+			ViewerCount:  s.ViewerCount,
+			Type:         s.Type,
+			GameName:     s.GameName,
+			GameID:       s.GameID,
+			Language:     s.Language,
+			Tags:         s.TagIDs,
+			Mature:       s.IsMature,
+			StartedAt:    s.StartedAt.Format(time.RFC3339),
+			UserID:       s.UserID,
+		}
+	} else {
+		return nil, nil
+	}
+
+	return stream, nil
+}

--- a/src/server/api/v2/gql/scheme/scheme.gql
+++ b/src/server/api/v2/gql/scheme/scheme.gql
@@ -214,6 +214,10 @@ type User {
   banned: Boolean!
   # Get the user's maximum channel emote slots
   emote_slots: Int!
+  # Get the user's follower count
+  follower_count: Int!
+  # Get the user's current live broadcast
+  broadcast: Broadcast
 }
 
 type UserPartial {
@@ -291,4 +295,19 @@ type Ban {
 type Meta {
   announcement: String!
   featured_broadcast: String!
+}
+
+type Broadcast {
+  id: String!
+  title: String!
+  thumbnail_url: String!
+  viewer_count: Int!
+  type: String!
+  game_name: String!
+  game_id: String!
+  language: String!
+  tags: [String!]!
+  mature: Boolean!
+  started_at: String!
+  user_id: String!
 }

--- a/src/server/api/v2/proxy/twitch.go
+++ b/src/server/api/v2/proxy/twitch.go
@@ -25,13 +25,10 @@ func GetTwitchUser(ctx context.Context, login string) (*userTwitch, error) {
 	}
 
 	// Send request
-	resp, err := cache.CacheGetRequest(ctx, uri, time.Minute*30, time.Minute*15, struct {
-		Key   string
-		Value string
-	}{Key: "Client-ID", Value: configure.Config.GetString("twitch_client_id")}, struct {
-		Key   string
-		Value string
-	}{Key: "Authorization", Value: fmt.Sprintf("Bearer %v", token)})
+	resp, err := cache.CacheGetRequest(ctx, uri, time.Minute*30, time.Minute*15,
+		RequestHeadersKeyValuePairs{Key: "Client-ID", Value: configure.Config.GetString("twitch_client_id")},
+		RequestHeadersKeyValuePairs{Key: "Authorization", Value: fmt.Sprintf("Bearer %v", token)},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -60,13 +57,10 @@ func GetTwitchStreams(ctx context.Context, logins ...string) (*streamsResponseTw
 	}
 
 	// Send request
-	resp, err := cache.CacheGetRequest(ctx, uri, time.Minute*5, time.Minute*2, struct {
-		Key   string
-		Value string
-	}{Key: "Client-ID", Value: configure.Config.GetString("twitch_client_id")}, struct {
-		Key   string
-		Value string
-	}{Key: "Authorization", Value: fmt.Sprintf("Bearer %v", token)})
+	resp, err := cache.CacheGetRequest(ctx, uri, time.Minute*5, time.Minute*2,
+		RequestHeadersKeyValuePairs{Key: "Client-ID", Value: configure.Config.GetString("twitch_client_id")},
+		RequestHeadersKeyValuePairs{Key: "Authorization", Value: fmt.Sprintf("Bearer %v", token)},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -77,6 +71,28 @@ func GetTwitchStreams(ctx context.Context, logins ...string) (*streamsResponseTw
 	}
 
 	return streamResponse, nil
+}
+
+func GetTwitchFollowerCount(ctx context.Context, id string) (int32, error) {
+	uri := fmt.Sprintf("%v/helix/users/follows?to_id=%v", baseUrlTwitch, id)
+
+	// Get auth
+	headers, err := getTwitchAuthorizeHeaders(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	resp, err := cache.CacheGetRequest(ctx, uri, time.Hour*3, time.Minute*1, headers...)
+	if err != nil {
+		return 0, err
+	}
+
+	var response *userFollowersResponseTwitch
+	if err := json.Unmarshal(resp.Body, &response); err != nil {
+		return 0, err
+	}
+
+	return response.Total, nil
 }
 
 type userResponseTwitch struct {
@@ -114,4 +130,34 @@ type streamTwitch struct {
 	ThumbnailURL string    `json:"thumbnail_url"`
 	TagIDs       []string  `json:"tag_ids"`
 	IsMature     bool      `json:"is_mature"`
+}
+
+type userFollowersResponseTwitch struct {
+	Total int32 `json:"total"`
+}
+
+type RequestHeadersKeyValuePairs struct {
+	Key   string
+	Value string
+}
+
+func getTwitchAuthorizeHeaders(ctx context.Context) ([]struct {
+	Key   string
+	Value string
+}, error) {
+	token, err := auth.GetAuth(ctx)
+	if err != nil {
+		return []struct {
+			Key   string
+			Value string
+		}{}, err
+	}
+
+	return []struct {
+		Key   string
+		Value string
+	}{
+		{Key: "Client-ID", Value: configure.Config.GetString("twitch_client_id")},
+		{Key: "Authorization", Value: fmt.Sprintf("Bearer %v", token)},
+	}, nil
 }

--- a/src/server/api/v2/proxy/twitch.go
+++ b/src/server/api/v2/proxy/twitch.go
@@ -19,16 +19,13 @@ func GetTwitchUser(ctx context.Context, login string) (*userTwitch, error) {
 	uri := fmt.Sprintf("%v/helix/users?login=%v", baseUrlTwitch, login)
 
 	// Get auth
-	token, err := auth.GetAuth(ctx)
+	headers, err := getTwitchAuthorizeHeaders(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	// Send request
-	resp, err := cache.CacheGetRequest(ctx, uri, time.Minute*30, time.Minute*15,
-		RequestHeadersKeyValuePairs{Key: "Client-ID", Value: configure.Config.GetString("twitch_client_id")},
-		RequestHeadersKeyValuePairs{Key: "Authorization", Value: fmt.Sprintf("Bearer %v", token)},
-	)
+	resp, err := cache.CacheGetRequest(ctx, uri, time.Minute*30, time.Minute*15, headers...)
 	if err != nil {
 		return nil, err
 	}
@@ -51,16 +48,13 @@ func GetTwitchStreams(ctx context.Context, logins ...string) (*streamsResponseTw
 	uri := fmt.Sprintf("%v/helix/streams?user_login=%v", baseUrlTwitch, strings.Join(logins, ","))
 
 	// Get auth
-	token, err := auth.GetAuth(ctx)
+	headers, err := getTwitchAuthorizeHeaders(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	// Send request
-	resp, err := cache.CacheGetRequest(ctx, uri, time.Minute*5, time.Minute*2,
-		RequestHeadersKeyValuePairs{Key: "Client-ID", Value: configure.Config.GetString("twitch_client_id")},
-		RequestHeadersKeyValuePairs{Key: "Authorization", Value: fmt.Sprintf("Bearer %v", token)},
-	)
+	resp, err := cache.CacheGetRequest(ctx, uri, time.Minute*2+time.Second*30, time.Minute*2, headers...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adding two new fields to the `User` GQL type

- Broadcast: the user's active live broadcast, if any
- Follower Count: the user's current amount of followers

This is used for the User Page on the Web App.