### PR TITLE
Notification Permissions & Query Additions

### DIFF
--- a/src/mongo/datastructure/datastructure.go
+++ b/src/mongo/datastructure/datastructure.go
@@ -338,9 +338,10 @@ type Notification struct {
 	Title        string                    `json:"title" bson:"title"`                 // The notification's heading / title
 	MessageParts []NotificationMessagePart `json:"message_parts" bson:"message_parts"` // The parts making up the notification's formatted message
 
-	Read   bool     `json:"read" bson:"read,omitempty"`
-	Users  []*User  `json:"users" bson:"-"`  // The users mentioned in this notification
-	Emotes []*Emote `json:"emotes" bson:"-"` // The emotesm entioned in this notification
+	Read   bool      `json:"read" bson:"read,omitempty"`
+	ReadAt time.Time `json:"read_at" bson:"read_at,omitempty"`
+	Users  []*User   `json:"users" bson:"-"`  // The users mentioned in this notification
+	Emotes []*Emote  `json:"emotes" bson:"-"` // The emotesm entioned in this notification
 }
 
 type NotificationMessagePart struct {

--- a/src/mongo/datastructure/datastructure.go
+++ b/src/mongo/datastructure/datastructure.go
@@ -120,15 +120,16 @@ type User struct {
 	EmoteSlots      int32               `json:"emote_slots" bson:"emote_slots"` // User's maximum channel emote slots
 
 	// Relational Data
-	Emotes        *[]*Emote       `json:"emotes" bson:"-"`
-	OwnedEmotes   *[]*Emote       `json:"owned_emotes" bson:"-"`
-	Editors       *[]*User        `json:"editors" bson:"-"`
-	Role          *Role           `json:"role" bson:"-"`
-	EditorIn      *[]*User        `json:"editor_in" bson:"-"`
-	AuditEntries  *[]*AuditLog    `json:"audit_entries" bson:"-"`
-	Reports       *[]*Report      `json:"reports" bson:"-"`
-	Bans          *[]*Ban         `json:"bans" bson:"-"`
-	Notifications []*Notification `json:"-" bson:"-"`
+	Emotes            *[]*Emote       `json:"emotes" bson:"-"`
+	OwnedEmotes       *[]*Emote       `json:"owned_emotes" bson:"-"`
+	Editors           *[]*User        `json:"editors" bson:"-"`
+	Role              *Role           `json:"role" bson:"-"`
+	EditorIn          *[]*User        `json:"editor_in" bson:"-"`
+	AuditEntries      *[]*AuditLog    `json:"audit_entries" bson:"-"`
+	Reports           *[]*Report      `json:"reports" bson:"-"`
+	Bans              *[]*Ban         `json:"bans" bson:"-"`
+	Notifications     []*Notification `json:"-" bson:"-"`
+	NotificationCount *int64          `json:"-" bson:"-"`
 }
 
 // Get the user's maximum emote slot count

--- a/src/mongo/datastructure/datastructure.go
+++ b/src/mongo/datastructure/datastructure.go
@@ -336,7 +336,7 @@ type Notification struct {
 	Title        string                    `json:"title" bson:"title"`                 // The notification's heading / title
 	MessageParts []NotificationMessagePart `json:"message_parts" bson:"message_parts"` // The parts making up the notification's formatted message
 
-	Read   bool     `json:"read" bson:"read"`
+	Read   bool     `json:"read" bson:"read,omitempty"`
 	Users  []*User  `json:"users" bson:"-"`  // The users mentioned in this notification
 	Emotes []*Emote `json:"emotes" bson:"-"` // The emotesm entioned in this notification
 }

--- a/src/mongo/datastructure/datastructure.go
+++ b/src/mongo/datastructure/datastructure.go
@@ -120,14 +120,15 @@ type User struct {
 	EmoteSlots      int32               `json:"emote_slots" bson:"emote_slots"` // User's maximum channel emote slots
 
 	// Relational Data
-	Emotes       *[]*Emote    `json:"emotes" bson:"-"`
-	OwnedEmotes  *[]*Emote    `json:"owned_emotes" bson:"-"`
-	Editors      *[]*User     `json:"editors" bson:"-"`
-	Role         *Role        `json:"role" bson:"-"`
-	EditorIn     *[]*User     `json:"editor_in" bson:"-"`
-	AuditEntries *[]*AuditLog `json:"audit_entries" bson:"-"`
-	Reports      *[]*Report   `json:"reports" bson:"-"`
-	Bans         *[]*Ban      `json:"bans" bson:"-"`
+	Emotes        *[]*Emote       `json:"emotes" bson:"-"`
+	OwnedEmotes   *[]*Emote       `json:"owned_emotes" bson:"-"`
+	Editors       *[]*User        `json:"editors" bson:"-"`
+	Role          *Role           `json:"role" bson:"-"`
+	EditorIn      *[]*User        `json:"editor_in" bson:"-"`
+	AuditEntries  *[]*AuditLog    `json:"audit_entries" bson:"-"`
+	Reports       *[]*Report      `json:"reports" bson:"-"`
+	Bans          *[]*Ban         `json:"bans" bson:"-"`
+	Notifications []*Notification `json:"-" bson:"-"`
 }
 
 // Get the user's maximum emote slot count

--- a/src/server/api/v2/gql/resolvers/mutation/notification.go
+++ b/src/server/api/v2/gql/resolvers/mutation/notification.go
@@ -3,6 +3,7 @@ package mutation_resolvers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/SevenTV/ServerGo/src/mongo"
 	"github.com/SevenTV/ServerGo/src/mongo/datastructure"
@@ -39,7 +40,8 @@ func (*MutationResolver) MarkNotificationsRead(ctx context.Context, args struct 
 		"target": usr.ID,
 	}, bson.M{
 		"$set": bson.M{
-			"read": true,
+			"read":    true,
+			"read_at": time.Now(),
 		},
 	})
 	if err != nil {

--- a/src/server/api/v2/gql/resolvers/query/notification.go
+++ b/src/server/api/v2/gql/resolvers/query/notification.go
@@ -3,6 +3,7 @@ package query_resolvers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/SevenTV/ServerGo/src/mongo/datastructure"
 	"github.com/SevenTV/ServerGo/src/server/api/actions"
@@ -34,6 +35,19 @@ func (r *NotificationResolver) Announcement() bool {
 
 func (r *NotificationResolver) Title() string {
 	return r.v.Title
+}
+
+func (r *NotificationResolver) Timestamp() string {
+	return r.v.ID.Timestamp().Format(time.RFC3339)
+}
+
+func (r *NotificationResolver) ReadAt() *string {
+	if r.v.ReadAt.IsZero() {
+		return nil
+	}
+
+	date := r.v.ReadAt.Format(time.RFC3339)
+	return &date
 }
 
 func (r *NotificationResolver) MessageParts() []*messagePart {

--- a/src/server/api/v2/gql/resolvers/query/user.go
+++ b/src/server/api/v2/gql/resolvers/query/user.go
@@ -540,9 +540,20 @@ func (r *UserResolver) Broadcast() (*datastructure.Broadcast, error) {
 }
 
 func (r *UserResolver) Notifications() ([]*NotificationResolver, error) {
+	usr, ok := r.ctx.Value(utils.UserKey).(*datastructure.User)
+	if !ok {
+		return []*NotificationResolver{}, nil
+	}
+
+	// Check permissions: user must be
+	if !usr.HasPermission(datastructure.RolePermissionManageUsers) {
+		if r.v.ID != usr.ID {
+			return []*NotificationResolver{}, nil
+		}
+	}
+
 	// Find notifications readable by this user
 	var data []*datastructure.Notification
-
 	pipeline := mongo.Pipeline{
 		bson.D{ // Step 1: Match only readstates where the target is the user
 			bson.E{

--- a/src/server/api/v2/gql/resolvers/query/user.go
+++ b/src/server/api/v2/gql/resolvers/query/user.go
@@ -548,7 +548,16 @@ func (r *UserResolver) Notifications() ([]*NotificationResolver, error) {
 	// Check permissions: user must be
 	if !usr.HasPermission(datastructure.RolePermissionManageUsers) {
 		if r.v.ID != usr.ID {
-			return []*NotificationResolver{}, nil
+			isEditor := false
+			for _, e := range r.v.EditorIDs {
+				if e == usr.ID {
+					isEditor = true
+					break
+				}
+			}
+			if !isEditor {
+				return []*NotificationResolver{}, nil
+			}
 		}
 	}
 

--- a/src/server/api/v2/gql/resolvers/query/user.go
+++ b/src/server/api/v2/gql/resolvers/query/user.go
@@ -49,12 +49,16 @@ func GenerateUserResolver(ctx context.Context, user *datastructure.User, userID 
 	}
 
 	usr, usrValid := ctx.Value(utils.UserKey).(*datastructure.User)
-	actorCanEdit := user.ID == usr.ID
-	if !actorCanEdit {
-		for _, e := range user.EditorIDs {
-			if e == usr.ID {
-				actorCanEdit = true
-				break
+	actorCanEdit := false
+	if usr != nil {
+		actorCanEdit = usr.ID == user.ID
+
+		if !actorCanEdit {
+			for _, e := range user.EditorIDs {
+				if e == usr.ID {
+					actorCanEdit = true
+					break
+				}
 			}
 		}
 	}

--- a/src/server/api/v2/gql/resolvers/query/user.go
+++ b/src/server/api/v2/gql/resolvers/query/user.go
@@ -232,7 +232,12 @@ func GenerateUserResolver(ctx context.Context, user *datastructure.User, userID 
 		_ = res.All(ctx, user.Bans)
 	}
 
-	if _, ok := fields["notifications"]; ok && usrValid && actorCanEdit {
+	_, getNotifyData := fields["notifications"]
+	if !getNotifyData {
+		_, getNotifyData = fields["notification_count"]
+	}
+
+	if getNotifyData && usrValid && actorCanEdit {
 		// Find notifications readable by this user
 		pipeline := mongo.Pipeline{
 			bson.D{ // Step 1: Match only readstates where the target is the user

--- a/src/server/api/v2/gql/scheme/scheme.gql
+++ b/src/server/api/v2/gql/scheme/scheme.gql
@@ -233,8 +233,10 @@ type User {
   follower_count: Int!
   # Get the user's current live broadcast
   broadcast: Broadcast
-  # Get the user's unread notifications
+  # Get the user's most recent notifications
   notifications: [Notification]!
+  # Get amount of unread notifications this user has
+  notification_count: Int!
 }
 
 type UserPartial {

--- a/src/server/api/v2/gql/scheme/scheme.gql
+++ b/src/server/api/v2/gql/scheme/scheme.gql
@@ -339,6 +339,8 @@ type Notification {
   announcement: Boolean!
   # The title of the notification
   title: String!
+  # When this notification was created
+  timestamp: String!
   # The notification's formattable message parts
   message_parts: [NotificationMessagePart!]!
 
@@ -348,6 +350,8 @@ type Notification {
   emotes: [Emote]!
   # Whether the notification has been read
   read: Boolean!
+  # When this notification was read
+  read_at: String
 }
 
 type NotificationMessagePart {


### PR DESCRIPTION
Adding permission checks for gql notification resolvers, preventing any user from reading another users' notifications unauthorized.