### PR TITLE
API/GQL - Emote Channels Pagination

### DIFF
--- a/src/mongo/mongo.go
+++ b/src/mongo/mongo.go
@@ -77,6 +77,7 @@ func init() {
 		{Keys: bson.M{"login": 1}, Options: options.Index().SetUnique(true)},
 		{Keys: bson.M{"rank": 1}},
 		{Keys: bson.M{"editors": 1}},
+		{Keys: bson.M{"emotes": 1}},
 	})
 	if err != nil {
 		log.WithError(err).Fatal("mongo")

--- a/src/mongo/mongo.go
+++ b/src/mongo/mongo.go
@@ -75,7 +75,7 @@ func init() {
 	_, err = Database.Collection("users").Indexes().CreateMany(ctx, []mongo.IndexModel{
 		{Keys: bson.M{"id": 1}, Options: options.Index().SetUnique(true)},
 		{Keys: bson.M{"login": 1}, Options: options.Index().SetUnique(true)},
-		{Keys: bson.M{"rank": 1}},
+		{Keys: bson.M{"role": 1}},
 		{Keys: bson.M{"editors": 1}},
 		{Keys: bson.M{"emotes": 1}},
 	})

--- a/src/server/api/v2/gql/resolvers/query/emotes.go
+++ b/src/server/api/v2/gql/resolvers/query/emotes.go
@@ -62,17 +62,19 @@ func GenerateEmoteResolver(ctx context.Context, emote *datastructure.Emote, emot
 	}
 
 	if emote.ChannelCount == nil {
-		// Get count of notifications
-		count, err := cache.GetCollectionSize(ctx, "users", bson.M{
-			"emotes": bson.M{
-				"$in": []primitive.ObjectID{emote.ID},
-			},
-		})
-		if err != nil {
-			return nil, err
-		}
+		if _, ok := fields["channel_count"]; ok {
+			// Get count of notifications
+			count, err := cache.GetCollectionSize(ctx, "users", bson.M{
+				"emotes": bson.M{
+					"$in": []primitive.ObjectID{emote.ID},
+				},
+			})
+			if err != nil {
+				return nil, err
+			}
 
-		emote.ChannelCount = utils.Int32Pointer(int32(count))
+			emote.ChannelCount = utils.Int32Pointer(int32(count))
+		}
 	}
 
 	usr, usrValid := ctx.Value(utils.UserKey).(*datastructure.User)

--- a/src/server/api/v2/gql/resolvers/query/emotes.go
+++ b/src/server/api/v2/gql/resolvers/query/emotes.go
@@ -226,7 +226,7 @@ func (r *EmoteResolver) Channels(ctx context.Context, args struct {
 	if args.Page != nil {
 		page = *args.Page
 		if page < 1 {
-			return nil, fmt.Errorf("Page must be 1 or higher")
+			page = 1
 		}
 	}
 
@@ -234,11 +234,8 @@ func (r *EmoteResolver) Channels(ctx context.Context, args struct {
 	limit := int32(20)
 	if args.Limit != nil {
 		limit = *args.Limit
-		if limit < 1 {
-			return nil, fmt.Errorf("Limit cannot be less than 1")
-		}
-		if limit > 250 {
-			return nil, fmt.Errorf("Limit cannot be more than 250")
+		if limit < 1 || limit > 250 {
+			limit = 250
 		}
 	}
 

--- a/src/server/api/v2/gql/scheme/scheme.gql
+++ b/src/server/api/v2/gql/scheme/scheme.gql
@@ -140,8 +140,6 @@ input ThirdPartyEmoteOptions {
 }
 
 type Emote {
-  # Get the channels the emote is added to
-  channels(page: Int, limit: Int): [UserPartial]
   # Id of the emote
   id: String!
   # name of the emote
@@ -160,6 +158,10 @@ type Emote {
   created_at: String!
   # Get audit log entries for this emote.
   audit_entries: [AuditLog!]
+  # Get the channels the emote is added to
+  channels(page: Int, limit: Int): [UserPartial]
+  # Get the amount of channels the emote is added to
+  channel_count: Int!
   # Get the owner of this emote.
   owner: User
   # Get the reports on emote. Requries Permission.

--- a/src/server/api/v2/gql/scheme/scheme.gql
+++ b/src/server/api/v2/gql/scheme/scheme.gql
@@ -140,6 +140,8 @@ input ThirdPartyEmoteOptions {
 }
 
 type Emote {
+  # Get the channels the emote is added to
+  channels(page: Int, limit: Int): [UserPartial]
   # Id of the emote
   id: String!
   # name of the emote
@@ -158,8 +160,6 @@ type Emote {
   created_at: String!
   # Get audit log entries for this emote.
   audit_entries: [AuditLog!]
-  # Get the channels the emote is added to
-  channels: [User]
   # Get the owner of this emote.
   owner: User
   # Get the reports on emote. Requries Permission.

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -160,6 +160,10 @@ func StringPointer(s string) *string {
 	return &s
 }
 
+func Int32Pointer(i int32) *int32 {
+	return &i
+}
+
 func Int64Pointer(i int64) *int64 {
 	return &i
 }


### PR DESCRIPTION
Adding an optional pagination query to the `channels` field of the `Emote` type in GQL, as well as limiting the default amount of channels returned when the query is unspecified