### PR TITLE
API/GQL - Meta Mutation

### DIFF
--- a/src/server/api/v2/gql/resolvers/mutation/meta.go
+++ b/src/server/api/v2/gql/resolvers/mutation/meta.go
@@ -24,7 +24,9 @@ func (*MutationResolver) EditApp(ctx context.Context, args struct {
 
 	// Edit featured broadcast
 	if args.Properties.FeaturedBroadcast != nil {
-		redis.Client.Set(ctx, "meta:featured_broadcast", *args.Properties.FeaturedBroadcast, 0)
+		if err := redis.Client.Set(ctx, "meta:featured_broadcast", *args.Properties.FeaturedBroadcast, 0).Err(); err != nil {
+			return nil, err
+		}
 	}
 
 	return &response{}, nil

--- a/src/server/api/v2/gql/resolvers/mutation/meta.go
+++ b/src/server/api/v2/gql/resolvers/mutation/meta.go
@@ -29,7 +29,10 @@ func (*MutationResolver) EditApp(ctx context.Context, args struct {
 		}
 	}
 
-	return &response{}, nil
+	return &response{
+		Message: "OK",
+		Status:  200,
+	}, nil
 }
 
 type MetaInput struct {

--- a/src/server/api/v2/gql/resolvers/mutation/meta.go
+++ b/src/server/api/v2/gql/resolvers/mutation/meta.go
@@ -1,0 +1,35 @@
+package mutation_resolvers
+
+import (
+	"context"
+
+	"github.com/SevenTV/ServerGo/src/mongo/datastructure"
+	"github.com/SevenTV/ServerGo/src/redis"
+	"github.com/SevenTV/ServerGo/src/server/api/v2/gql/resolvers"
+	"github.com/SevenTV/ServerGo/src/utils"
+)
+
+func (*MutationResolver) EditApp(ctx context.Context, args struct {
+	Properties struct {
+		FeaturedBroadcast *string
+	}
+}) (*response, error) {
+	usr, ok := ctx.Value(utils.UserKey).(*datastructure.User)
+	if !ok {
+		return nil, resolvers.ErrLoginRequired
+	}
+	if !usr.HasPermission(datastructure.RolePermissionEditApplicationMeta) {
+		return nil, resolvers.ErrAccessDenied
+	}
+
+	// Edit featured broadcast
+	if args.Properties.FeaturedBroadcast != nil {
+		redis.Client.Set(ctx, "meta:featured_broadcast", *args.Properties.FeaturedBroadcast, 0)
+	}
+
+	return &response{}, nil
+}
+
+type MetaInput struct {
+	FeaturedBroadcast string `json:"featured_broadcast"`
+}

--- a/src/server/api/v2/gql/scheme/scheme.gql
+++ b/src/server/api/v2/gql/scheme/scheme.gql
@@ -34,6 +34,8 @@ type Mutation {
   unbanUser(victim_id: String!, reason: String): Response
   # Mark a notification as read
   markNotificationsRead(notification_ids: [String!]!): Response
+  # Edit the application
+  editApp(properties: MetaInput!): Response
 }
 
 type Response {
@@ -104,6 +106,10 @@ input UserInput {
 
 input ChannelEmoteInput {
   alias: String
+}
+
+input MetaInput {
+  featured_broadcast: String
 }
 
 type AuditLog {


### PR DESCRIPTION
Adding a GQL mutation command for application meta. Currently, this only affects the featured stream