### PR TITLE
Zerowidth Emote Visibility Flag

### DIFF
--- a/src/mongo/datastructure/datastructure.go
+++ b/src/mongo/datastructure/datastructure.go
@@ -213,6 +213,7 @@ const (
 	RolePermissionEditEmoteGlobalState                   // 1024 - (Elevated) Allows editing the global state of an emote
 	RolePermissionEditApplicationMeta                    // 2048 - (Elevated) Allows editing global app metadata, such as the active featured broadcast
 	RolePermissionManageEntitlements                     // 4096 - (Elevated) Allows granting and revoking entitlements to and from users
+	RolePermissionUseZerowidthEmote                      // 8192 - Allows zero-width emotes to be enabled
 
 	RolePermissionAll int64 = (1 << iota) - 1
 )

--- a/src/mongo/datastructure/datastructure.go
+++ b/src/mongo/datastructure/datastructure.go
@@ -61,6 +61,7 @@ const (
 	EmoteVisibilityOverrideFFZ
 	EmoteVisibilityOverrideTwitchGlobal
 	EmoteVisibilityOverrideTwitchSubscriber
+	EmoteVisibilityZerowidth
 
 	EmoteVisibilityAll int32 = (1 << iota) - 1
 )

--- a/src/server/api/v2/gql/resolvers/query/user.go
+++ b/src/server/api/v2/gql/resolvers/query/user.go
@@ -436,7 +436,12 @@ func (r *UserResolver) Emotes() ([]*EmoteResolver, error) {
 	emotes := datastructure.UserUtil.GetAliasedEmotes(r.v)
 	result := []*EmoteResolver{}
 
+	zeroWidthOK := r.v.HasPermission(datastructure.RolePermissionUseZerowidthEmote)
 	for _, e := range emotes {
+		if !zeroWidthOK && utils.BitField.HasBits(int64(e.Visibility), int64(datastructure.EmoteVisibilityZerowidth)) {
+			continue // Skip if the emote is zero-width and user lacks permission
+		}
+
 		r, err := GenerateEmoteResolver(r.ctx, e, nil, r.fields["emotes"].Children)
 		if err != nil {
 			log.WithError(err).Error("generation")


### PR DESCRIPTION
Adding a zerowidth flag into the visibility field of the Emote object to instruct clients this is a zero-width emote.

The flag corresponds to `1 << 7`